### PR TITLE
Close sqlite connections after each store operation (Windows file locks)

### DIFF
--- a/moonshine_state.py
+++ b/moonshine_state.py
@@ -8,7 +8,7 @@ import tempfile
 from pathlib import Path
 from typing import List, Optional
 
-from moonshine.utils import overlap_score, tokenize
+from moonshine.utils import ClosingSqliteConnection, overlap_score, tokenize
 
 
 class SessionStateDB(object):
@@ -23,7 +23,7 @@ class SessionStateDB(object):
         self._initialize()
 
     def _connect(self) -> sqlite3.Connection:
-        connection = sqlite3.connect(str(self.db_path))
+        connection = sqlite3.connect(str(self.db_path), factory=ClosingSqliteConnection)
         connection.row_factory = sqlite3.Row
         try:
             connection.execute("PRAGMA journal_mode=WAL")

--- a/storage/knowledge_store.py
+++ b/storage/knowledge_store.py
@@ -11,7 +11,15 @@ from typing import Dict, List, Optional, Sequence
 
 from moonshine.moonshine_constants import MoonshinePaths
 from moonshine.storage.knowledge_vector_store import KnowledgeVectorIndex
-from moonshine.utils import append_jsonl, atomic_write, overlap_score, shorten, tokenize, utc_now
+from moonshine.utils import (
+    ClosingSqliteConnection,
+    append_jsonl,
+    atomic_write,
+    overlap_score,
+    shorten,
+    tokenize,
+    utc_now,
+)
 
 
 class KnowledgeStore(object):
@@ -26,7 +34,7 @@ class KnowledgeStore(object):
         self._initialize()
 
     def _connect(self) -> sqlite3.Connection:
-        connection = sqlite3.connect(str(self.db_path))
+        connection = sqlite3.connect(str(self.db_path), factory=ClosingSqliteConnection)
         connection.row_factory = sqlite3.Row
         try:
             connection.execute("PRAGMA journal_mode=WAL")

--- a/storage/knowledge_vector_store.py
+++ b/storage/knowledge_vector_store.py
@@ -19,7 +19,7 @@ except ImportError:  # pragma: no cover
     Request = urlopen = None
 
 from moonshine.moonshine_constants import MoonshinePaths
-from moonshine.utils import ensure_directory, tokenize
+from moonshine.utils import ClosingSqliteConnection, ensure_directory, tokenize
 
 
 def _unit_vector(vector: Sequence[float]) -> List[float]:
@@ -160,7 +160,7 @@ class SQLiteVectorBackend(object):
         self._initialize()
 
     def _connect(self) -> sqlite3.Connection:
-        connection = sqlite3.connect(str(self.db_path))
+        connection = sqlite3.connect(str(self.db_path), factory=ClosingSqliteConnection)
         connection.row_factory = sqlite3.Row
         return connection
 

--- a/tests/test_architecture.py
+++ b/tests/test_architecture.py
@@ -32,7 +32,7 @@ from moonshine.run_agent import AgentEvent, main as run_agent_main, render_agent
 from moonshine.skills.skill_document import parse_skill_document, validate_skill_document
 from moonshine.storage.knowledge_vector_store import SQLiteVectorBackend
 from moonshine.structured_tasks import get_structured_task, list_structured_tasks
-from moonshine.utils import append_jsonl, atomic_write, read_json, read_jsonl, read_text
+from moonshine.utils import ClosingSqliteConnection, append_jsonl, atomic_write, read_json, read_jsonl, read_text
 from moonshine.json_schema import JsonSchemaValidationError
 
 
@@ -1439,7 +1439,7 @@ class MoonshineArchitectureTestCase(unittest.TestCase):
 
         self.assertTrue(matches)
         self.assertIn("REBUILT_TOOL_INDEX_SENTINEL", matches[0]["_search_text"])
-        with sqlite3.connect(str(self.app.paths.sessions_db)) as connection:
+        with sqlite3.connect(str(self.app.paths.sessions_db), factory=ClosingSqliteConnection) as connection:
             row = connection.execute(
                 """
                 SELECT metadata_json FROM session_records
@@ -8458,7 +8458,7 @@ description: Stale runtime builtin skill that no longer exists in packaged asset
         self.assertIn('"source_type": "manual"', markdown)
 
     def test_session_database_uses_wal_mode(self):
-        with sqlite3.connect(str(self.app.paths.sessions_db)) as connection:
+        with sqlite3.connect(str(self.app.paths.sessions_db), factory=ClosingSqliteConnection) as connection:
             mode = connection.execute("PRAGMA journal_mode").fetchone()[0]
         self.assertEqual(str(mode).lower(), "wal")
 

--- a/tests/test_sqlite_connection_cleanup.py
+++ b/tests/test_sqlite_connection_cleanup.py
@@ -1,0 +1,44 @@
+"""Regression test: store operations must close their sqlite connections.
+
+Real Windows bug: ``with sqlite3.connect(...) as conn`` commits the transaction
+on exit but NEVER closes the connection (the closing-context-manager gotcha).
+``moonshine_state.SessionStateDB``, ``storage.knowledge_store.KnowledgeStore``
+and ``storage.knowledge_vector_store.SQLiteVectorBackend`` all used that
+pattern for every operation, so each call leaked an open handle on the database
+file. On Windows those lingering handles lock the file — tempdir cleanup fails
+with PermissionError WinError 32, which was the dominant failure mode of the
+whole Windows test suite and was masked by
+``tempfile.TemporaryDirectory(ignore_cleanup_errors=True)`` in existing tests.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+
+from moonshine.app import MoonshineApp
+
+
+class SqliteConnectionCleanupTest(unittest.TestCase):
+    def test_app_usage_leaves_no_locked_files(self):
+        """After ordinary app use the home dir must be fully deletable.
+
+        TemporaryDirectory without ignore_cleanup_errors raises PermissionError
+        at cleanup if any store leaked an open handle on a Windows-locked file.
+        """
+        temp_dir = tempfile.TemporaryDirectory()  # deliberately strict cleanup
+        self.addCleanup(temp_dir.cleanup)
+
+        app = MoonshineApp(home=temp_dir.name)
+        app.start_shell_state(mode="research", project_slug="lock_repro")
+        app.agent.memory_manager.knowledge_store.add_conclusion(
+            title="cleanup probe",
+            statement="store writes must not leak sqlite handles",
+            project_slug="lock_repro",
+        )
+        # Leaving the method drops the app reference; addCleanup then deletes
+        # the whole home tree, which fails on Windows while any handle is open.
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/utils.py
+++ b/utils.py
@@ -6,6 +6,7 @@ import hashlib
 import json
 import os
 import re
+import sqlite3
 import unicodedata
 from functools import lru_cache
 from datetime import datetime
@@ -16,6 +17,23 @@ try:
     import tiktoken
 except ImportError:  # pragma: no cover
     tiktoken = None
+
+
+class ClosingSqliteConnection(sqlite3.Connection):
+    """sqlite3.Connection whose context-manager exit also closes the handle.
+
+    ``with sqlite3.connect(...) as conn`` commits or rolls back the transaction
+    but never closes the connection, so every store call leaking through that
+    pattern keeps an open handle on the database file. On Windows those
+    handles lock the file (PermissionError WinError 32 when the directory is
+    deleted); use this factory anywhere the ``with connect()`` idiom is used.
+    """
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        try:
+            super().__exit__(exc_type, exc_value, traceback)
+        finally:
+            self.close()
 
 
 TOKEN_RE = re.compile(r"[A-Za-z0-9_]+|[\u4e00-\u9fff]+")


### PR DESCRIPTION
## Summary

`with sqlite3.connect(...) as conn` commits (or rolls back) the transaction on exit but **never closes the connection** — the classic sqlite3 context-manager gotcha. `SessionStateDB`, `KnowledgeStore` and `SQLiteVectorBackend` all used this idiom for every operation, so each store call leaked an open file handle on the database file.

On Windows those lingering handles lock `sessions.sqlite3` and the knowledge databases: deleting the app home directory or a test tempdir fails with `PermissionError: [WinError 32]`. (On POSIX the unlink succeeds anyway, which is why this stayed invisible.) This was the dominant failure mode of the Windows test suite, and it was masked by `TemporaryDirectory(ignore_cleanup_errors=True)` in the existing tests.

## Fix

- Add `ClosingSqliteConnection` in `utils.py`: a `sqlite3.Connection` subclass whose `__exit__` performs the usual commit/rollback and then closes the handle. Used as the `factory=` in the three stores' `_connect()`, so no call sites change.
- Fix the same raw-connect idiom in two architecture tests.
- Add `tests/test_sqlite_connection_cleanup.py`: ordinary app usage followed by a **strict** tempdir cleanup (no `ignore_cleanup_errors`). It fails deterministically without the fix and passes with it.

## Verification (isolated checkout of each ref, Windows 11, Python 3.11)

| | main (`a4132c7`) | this branch |
|---|---|---|
| failed | 187 | 43 |
| errors (teardown) | 38 | 0 |
| `WinError 32` traceback lines | ~500 | 0 |

- Negative control: the new regression test fails on `main` and passes on this branch.
- The remaining 43 failures are unrelated upstream test/code drift (e.g. `tool not exposed: manage_skill`, `KeyError: 'session_hits'`, tests expecting a `scratchpad.md` the code no longer writes). They are platform-independent (they fail the same way on any OS) and are intentionally left untouched here — I'd rather address them separately than grow this PR.

Independent of #1: this branch is based on current `main`, and the two can merge in either order.
